### PR TITLE
Adding engine legacy flag

### DIFF
--- a/reth/entrypoint.sh
+++ b/reth/entrypoint.sh
@@ -27,6 +27,7 @@ exec reth \
   --ws.addr 0.0.0.0 \
   --ws.port 8546 \
   --ws.origins "*" \
+  --engine.legacy \
   --authrpc.addr 0.0.0.0 \
   --authrpc.port 8551 \
   --authrpc.jwtsecret "${JWT_PATH}" ${EXTRA_OPTS}


### PR DESCRIPTION
Adding `--engine.legacy` flag to use legacy engine while new engine is still not battle tested. We should remove this in the future.