### PR TITLE
bump paradigmxyz/reth to v1.11.2, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "paradigmxyz/reth",
-      "version": "v1.11.1",
+      "version": "v1.11.2",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: reth
       args:
-        UPSTREAM_VERSION: v1.11.1
+        UPSTREAM_VERSION: v1.11.2
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data/reth
     volumes:


### PR DESCRIPTION
Bumps upstream version

- [paradigmxyz/reth](https://github.com/paradigmxyz/reth) from v1.11.1 to [v1.11.2](https://github.com/paradigmxyz/reth/releases/tag/v1.11.2)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)