### PR TITLE
bump paradigmxyz/reth to v2.1.0, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "paradigmxyz/reth",
-      "version": "v2.0.0",
+      "version": "v2.1.0",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: reth
       args:
-        UPSTREAM_VERSION: v2.0.0
+        UPSTREAM_VERSION: v2.1.0
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data/reth
     volumes:


### PR DESCRIPTION
Bumps upstream version

- [paradigmxyz/reth](https://github.com/paradigmxyz/reth) from v2.0.0 to [v2.1.0](https://github.com/paradigmxyz/reth/releases/tag/v2.1.0)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)