### PR TITLE
bump paradigmxyz/reth to v2.2.0, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "paradigmxyz/reth",
-      "version": "v2.1.0",
+      "version": "v2.2.0",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: reth
       args:
-        UPSTREAM_VERSION: v2.1.0
+        UPSTREAM_VERSION: v2.2.0
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data/reth
     volumes:

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoodi-reth.dnp.dappnode.eth",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "links": {
     "api": "http://hoodi-reth.dappnode:8545",
     "apiEngine": "http://hoodi-reth.dappnode:8551",

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "reth.dnp.dappnode.eth",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "links": {
     "api": "http://reth.dappnode:8545",
     "apiEngine": "http://reth.dappnode:8551",


### PR DESCRIPTION
Bumps upstream version

- [paradigmxyz/reth](https://github.com/paradigmxyz/reth) from v2.1.0 to [v2.2.0](https://github.com/paradigmxyz/reth/releases/tag/v2.2.0)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)