### PR TITLE
Add Reth snapshot and storage mode options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       RPC_MAX_BLOCKS_PER_FILTER: "0"
       EXTRA_OPTS: null
+      ARCHIVE_NODE: "false"
       DOWNLOAD_SNAPSHOT: "true"
       STORAGE_MODE: full
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     environment:
       RPC_MAX_BLOCKS_PER_FILTER: "0"
       EXTRA_OPTS: null
-      ARCHIVE_NODE: "false"
+      DOWNLOAD_SNAPSHOT: "true"
+      STORAGE_MODE: full
     restart: unless-stopped
 volumes:
   reth: {}

--- a/reth/entrypoint.sh
+++ b/reth/entrypoint.sh
@@ -8,7 +8,11 @@ echo "${JWT_SECRET}" >"${JWT_PATH}"
 
 post_jwt_to_dappmanager "${JWT_PATH}"
 
-case "${DOWNLOAD_SNAPSHOT:-true}" in
+DOWNLOAD_SNAPSHOT="${DOWNLOAD_SNAPSHOT:-true}"
+ARCHIVE_NODE="${ARCHIVE_NODE:-false}"
+STORAGE_MODE="${STORAGE_MODE:-full}"
+
+case "${DOWNLOAD_SNAPSHOT}" in
 true | false) ;;
 *)
   echo "[ERROR - entrypoint] DOWNLOAD_SNAPSHOT must be 'true' or 'false'"
@@ -16,7 +20,12 @@ true | false) ;;
   ;;
 esac
 
-case "${STORAGE_MODE:-full}" in
+if [ "${ARCHIVE_NODE}" = true ]; then
+  echo "[INFO - entrypoint] ARCHIVE_NODE=true detected; using STORAGE_MODE=archive"
+  STORAGE_MODE="archive"
+fi
+
+case "${STORAGE_MODE}" in
 full)
   STORAGE_MODE_FLAG="--full"
   SNAPSHOT_MODE_FLAG="--full"
@@ -29,17 +38,15 @@ archive)
   STORAGE_MODE_FLAG=""
   SNAPSHOT_MODE_FLAG="--archive"
   ;;
+custom)
+  STORAGE_MODE_FLAG="--block-interval 5 --prune.senderrecovery.full --prune.receipts.before 0 --prune.accounthistory.distance 10064 --prune.storagehistory.distance 10064"
+  SNAPSHOT_MODE_FLAG=""
+  ;;
 *)
-  echo "[ERROR - entrypoint] STORAGE_MODE must be 'full', 'minimal', or 'archive'"
+  echo "[ERROR - entrypoint] STORAGE_MODE must be 'full', 'minimal', 'archive', or 'custom'"
   exit 1
   ;;
 esac
-
-if [ "${ARCHIVE_NODE}" = true ]; then
-  echo "[INFO - entrypoint] ARCHIVE_NODE=true detected; using STORAGE_MODE=archive"
-  STORAGE_MODE_FLAG=""
-  SNAPSHOT_MODE_FLAG="--archive"
-fi
 
 is_data_dir_initialized() {
   for path in \
@@ -61,7 +68,9 @@ is_data_dir_initialized() {
 
 echo "[INFO - entrypoint] Running Reth client for network: ${NETWORK}"
 
-if [ "${DOWNLOAD_SNAPSHOT:-true}" = true ]; then
+if [ "${STORAGE_MODE}" = custom ]; then
+  echo "[INFO - entrypoint] STORAGE_MODE=custom selected; skipping snapshot download"
+elif [ "${DOWNLOAD_SNAPSHOT}" = true ]; then
   if is_data_dir_initialized; then
     echo "[INFO - entrypoint] Reth data directory already initialized; skipping snapshot download"
   else

--- a/reth/entrypoint.sh
+++ b/reth/entrypoint.sh
@@ -8,12 +8,78 @@ echo "${JWT_SECRET}" >"${JWT_PATH}"
 
 post_jwt_to_dappmanager "${JWT_PATH}"
 
+case "${DOWNLOAD_SNAPSHOT:-true}" in
+true | false) ;;
+*)
+  echo "[ERROR - entrypoint] DOWNLOAD_SNAPSHOT must be 'true' or 'false'"
+  exit 1
+  ;;
+esac
+
+case "${STORAGE_MODE:-full}" in
+full)
+  STORAGE_MODE_FLAG="--full"
+  SNAPSHOT_MODE_FLAG="--full"
+  ;;
+minimal)
+  STORAGE_MODE_FLAG="--minimal"
+  SNAPSHOT_MODE_FLAG="--minimal"
+  ;;
+archive)
+  STORAGE_MODE_FLAG=""
+  SNAPSHOT_MODE_FLAG="--archive"
+  ;;
+*)
+  echo "[ERROR - entrypoint] STORAGE_MODE must be 'full', 'minimal', or 'archive'"
+  exit 1
+  ;;
+esac
+
+if [ "${ARCHIVE_NODE}" = true ]; then
+  echo "[INFO - entrypoint] ARCHIVE_NODE=true detected; using STORAGE_MODE=archive"
+  STORAGE_MODE_FLAG=""
+  SNAPSHOT_MODE_FLAG="--archive"
+fi
+
+is_data_dir_initialized() {
+  for path in \
+    "${DATA_DIR}/${NETWORK}/db" \
+    "${DATA_DIR}/${NETWORK}/reth.toml" \
+    "${DATA_DIR}/${NETWORK}/static_files" \
+    "${DATA_DIR}/${NETWORK}/rocksdb" \
+    "${DATA_DIR}/db" \
+    "${DATA_DIR}/reth.toml" \
+    "${DATA_DIR}/static_files" \
+    "${DATA_DIR}/rocksdb"; do
+    if [ -e "${path}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 echo "[INFO - entrypoint] Running Reth client for network: ${NETWORK}"
+
+if [ "${DOWNLOAD_SNAPSHOT:-true}" = true ]; then
+  if is_data_dir_initialized; then
+    echo "[INFO - entrypoint] Reth data directory already initialized; skipping snapshot download"
+  else
+    echo "[INFO - entrypoint] Downloading ${NETWORK} ${SNAPSHOT_MODE_FLAG#--} snapshot before starting Reth"
+    # shellcheck disable=SC2086
+    reth \
+      download \
+      -y \
+      ${SNAPSHOT_MODE_FLAG} \
+      --chain "${NETWORK}" \
+      --datadir "${DATA_DIR}"
+  fi
+fi
 
 # shellcheck disable=SC2086
 exec reth \
   node \
-  $( [ "${ARCHIVE_NODE}" = false ] && printf -- "--block-interval 5 --prune.senderrecovery.full --prune.receipts.before 0 --prune.accounthistory.distance 10064 --prune.storagehistory.distance 10064" ) \
+  ${STORAGE_MODE_FLAG} \
   --chain "${NETWORK}" \
   --metrics 0.0.0.0:6060 \
   --datadir "${DATA_DIR}" \


### PR DESCRIPTION
## Summary
- add a DOWNLOAD_SNAPSHOT toggle enabled by default to run reth download before first startup
- add STORAGE_MODE with full, minimal, and archive profiles
- keep ARCHIVE_NODE=true as a backward-compatible archive override

## Testing
- sh -n reth/entrypoint.sh
- docker compose config
- git diff --check
- docker run --rm ghcr.io/paradigmxyz/reth:v2.2.0 node --help
- docker run --rm ghcr.io/paradigmxyz/reth:v2.2.0 download --help