### PR TITLE
ci: add tropibot repository_dispatch + metadata to sync-test, add attestation-test

### DIFF
--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: choice
         options: [lodestar, teku, prysm, nimbus, lighthouse]
+      ipfs_hash:
+        description: "Optional pre-built IPFS hash to test against"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   attestation-test:
@@ -20,4 +25,5 @@ jobs:
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
+      ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit

--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -1,8 +1,8 @@
-name: Execution Client Sync Test
+name: Proof of Attestation
 
 on:
   repository_dispatch:
-    types: [tropibot-sync-test]
+    types: [tropibot-attestation-test]
   workflow_dispatch:
     inputs:
       consensus_client:
@@ -10,15 +10,10 @@ on:
         required: true
         type: choice
         options: [lodestar, teku, prysm, nimbus, lighthouse]
-  pull_request:
-    branches:
-      - "main"
-    paths-ignore:
-      - "README.md"
 
 jobs:
-  sync-test:
-    uses: dappnode/workflows/.github/workflows/staking-sync-test.yml@master
+  attestation-test:
+    uses: dappnode/workflows/.github/workflows/staking-attestation-test.yml@master
     with:
       execution_client: "reth"
       consensus_client: ${{ github.event.client_payload.consensus_client || inputs.consensus_client || '' }}

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: choice
         options: [lodestar, teku, prysm, nimbus, lighthouse]
+      ipfs_hash:
+        description: "Optional pre-built IPFS hash to test against"
+        required: false
+        type: string
+        default: ""
   pull_request:
     branches:
       - "main"
@@ -25,4 +30,5 @@ jobs:
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
+      ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit


### PR DESCRIPTION
Wires the staker package test workflows into the TropiBot dispatch flow.

**sync-test.yml**
- Add `repository_dispatch` trigger for `tropibot-sync-test`.
- Forward `pr_number`, `head_ref`, and `sender` from the dispatch payload (with `pull_request` and `github.*` fallbacks) to the reusable `dappnode/workflows/.github/workflows/staking-sync-test.yml@master`.
- Keep existing `workflow_dispatch` and `pull_request` triggers.

**attestation-test.yml** (new)
- Triggers on `repository_dispatch: tropibot-attestation-test` and `workflow_dispatch`.
- Hard-codes `execution_client: "reth"`.
- Sources `consensus_client` from the dispatch payload or manual input (consensus choice).
- Forwards the same `pr_number` / `head_ref` / `sender` metadata mapping.
- Calls the reusable `dappnode/workflows/.github/workflows/staking-attestation-test.yml@master` with `secrets: inherit`.