### PR TITLE
ci: align staking test workflows with TropiBot retries

### DIFF
--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -24,6 +24,7 @@ jobs:
       consensus_client: ${{ github.event.client_payload.consensus_client || inputs.consensus_client || '' }}
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
+      head_sha: ${{ github.event.client_payload.head_sha || github.sha }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
       ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -29,6 +29,7 @@ jobs:
       consensus_client: ${{ github.event.client_payload.consensus_client || inputs.consensus_client || '' }}
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
+      head_sha: ${{ github.event.client_payload.head_sha || github.event.pull_request.head.sha || github.sha }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
       ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Forward an immutable \`head_sha\` to the reusable staking workflows so TropiBot retries always retest the exact PR head.
- Keep the existing \`ipfs_hash\` opt-in (skip build when supplied) for manual reruns of the PR head.
- Preserve the reth execution client default and the consensus-client choice for sync / attestation tests.

## Details

\`sync-test.yml\`
- Forwards \`head_sha: \${{ github.event.client_payload.head_sha || github.event.pull_request.head.sha || github.sha }}\`.
- Existing \`pull_request\`, \`workflow_dispatch\`, and \`repository_dispatch: [tropibot-sync-test]\` triggers preserved.
- \`ipfs_hash\` is optional and falls back to building the PR head when empty.

\`attestation-test.yml\`
- Forwards \`head_sha: \${{ github.event.client_payload.head_sha || github.sha }}\` (command/manual-only triggers).
- Supports \`workflow_dispatch\` and \`repository_dispatch: [tropibot-attestation-test]\`.
- \`ipfs_hash\` is optional and falls back to building the PR head when empty.

## Dependency

Depends on the corresponding \`dappnode/workflows\` reusable-workflow update being merged first.